### PR TITLE
bridge: change linux bridge to ovs

### DIFF
--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -143,7 +143,7 @@ func (node *Node) DeleteNode() []string {
 
 // DeleteSwitch Delete bridge
 func (br *Switch) DeleteSwitch() string {
-	deleteBrCmd := fmt.Sprintf("ip link delete %s", br.Name)
+	deleteBrCmd := fmt.Sprintf("ovs-vsctl del-br %s", br.Name)
 	return deleteBrCmd
 }
 
@@ -404,7 +404,7 @@ func NetnsLinkUp(netnsName string, linkName string) string {
 func (bridge *Switch) CreateSwitch() []string {
 	var createSwitchCmds []string
 
-	addSwitchCmd := fmt.Sprintf("ip link add %s type bridge", bridge.Name)
+	addSwitchCmd := fmt.Sprintf("ovs-vsctl add-br %s", bridge.Name)
 	createSwitchCmds = append(createSwitchCmds, addSwitchCmd)
 
 	bridgeUpCmd := HostLinkUp(bridge.Name)
@@ -445,7 +445,7 @@ func (inf *Interface) S2nLink(nodeName string) []string {
 	s2nLinkCmds = append(s2nLinkCmds, s2nLinkCmd)
 	s2nLinkCmds = append(s2nLinkCmds, NetnsLinkUp(nodeName, nodeinf))
 	s2nLinkCmds = append(s2nLinkCmds, HostLinkUp(peerBrInf))
-	setBrLinkCmd := fmt.Sprintf("ip link set dev %s master %s", peerBrInf, peerBr)
+	setBrLinkCmd := fmt.Sprintf("ovs-vsctl add-port %s %s", peerBr, peerBrInf)
 	s2nLinkCmds = append(s2nLinkCmds, setBrLinkCmd)
 
 	return s2nLinkCmds

--- a/internal/pkg/shell/shell_test.go
+++ b/internal/pkg/shell/shell_test.go
@@ -219,7 +219,7 @@ func TestSwitch_DeleteSwitch(t *testing.T) {
 					},
 				},
 			},
-			want: "ip link delete SW",
+			want: "ovs-vsctl del-br SW",
 		},
 	}
 	for _, tt := range tests {
@@ -716,7 +716,7 @@ func TestSwitch_CreateSwitch(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"ip link add SW type bridge", "ip link set SW up"},
+			want: []string{"ovs-vsctl add-br SW", "ip link set SW up"},
 		},
 	}
 	for _, tt := range tests {
@@ -815,7 +815,7 @@ func TestInterface_S2nLink(t *testing.T) {
 			args: args{
 				nodeName: "R1",
 			},
-			want: []string{"ip link add net0 netns R1 type veth peer name SW-R1", "ip netns exec R1 ip link set net0 up", "ip link set SW-R1 up", "ip link set dev SW-R1 master SW"},
+			want: []string{"ip link add net0 netns R1 type veth peer name SW-R1", "ip netns exec R1 ip link set net0 up", "ip link set SW-R1 up", "ovs-vsctl add-port SW SW-R1"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Content
I want to change to ovs because the switch function of [tinet example](https://github.com/slankdev/tinet/tree/master/examples) does not work on linux bridge