### PR TITLE
Add DNS options for Docker type

### DIFF
--- a/docs/specification_yml.md
+++ b/docs/specification_yml.md
@@ -9,8 +9,11 @@
 	- docker: node is docker container
 	- netns: node is just network namespace
 - image: specify docker-image
-- sysctls: set sysctls 
+- sysctls: set sysctls
 - mounts: mounts file/directory on the container
+- dns: set DNS resolver
+- dns_search: set DNS search domain
+
 
 ```
 nodes:

--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -56,6 +56,8 @@ type Node struct {
 	Interfaces     []Interface `yaml:"interfaces" mapstructure:"interfaces"`
 	Sysctls        []Sysctl    `yaml:"sysctls" mapstructure:"sysctls"`
 	Mounts         []string    `yaml:"mounts,flow" mapstructure:"mounts,flow"`
+	DNS            []string    `yaml:"dns,flow" mapstructure:"dns,flow"`
+	DNSSearches    []string    `yaml:"dns_search,flow" mapstructure:"dns_search,flow"`
 	HostNameIgnore bool        `yaml:"hostname_ignore" mapstructure:"hostname_ignore"`
 	EntryPoint     string      `yaml:"entrypoint" mapstructure:"entrypoint"`
 	ExtraArgs      string      `yaml:"docker_run_extra_args" mapstructure:"docker_run_extra_args"`
@@ -422,6 +424,18 @@ func (node *Node) CreateNode() []string {
 		if len(node.Mounts) != 0 {
 			for _, mount := range node.Mounts {
 				createNodeCmd += fmt.Sprintf("-v %s ", mount)
+			}
+		}
+
+		if len(node.DNS) != 0 {
+			for _, dns := range node.DNS {
+				createNodeCmd += fmt.Sprintf("--dns=%s ", dns)
+			}
+		}
+
+		if len(node.DNSSearches) != 0 {
+			for _, dns_search := range node.DNSSearches {
+				createNodeCmd += fmt.Sprintf("--dns-search=%s ", dns_search)
 			}
 		}
 

--- a/internal/pkg/shell/shell_test.go
+++ b/internal/pkg/shell/shell_test.go
@@ -116,6 +116,8 @@ func TestNode_DeleteNode(t *testing.T) {
 		Interfaces     []Interface
 		Sysctls        []Sysctl
 		Mounts         []string
+		DNS            []string
+		DNSSearches    []string
 		HostNameIgnore bool
 		EntryPoint     string
 		ExtraArgs      string
@@ -182,6 +184,8 @@ func TestNode_DeleteNode(t *testing.T) {
 				Interfaces:     tt.fields.Interfaces,
 				Sysctls:        tt.fields.Sysctls,
 				Mounts:         tt.fields.Mounts,
+				DNS:            tt.fields.DNS,
+				DNSSearches:    tt.fields.DNSSearches,
 				HostNameIgnore: tt.fields.HostNameIgnore,
 				EntryPoint:     tt.fields.EntryPoint,
 				ExtraArgs:      tt.fields.ExtraArgs,
@@ -485,6 +489,8 @@ func TestNode_CreateNode(t *testing.T) {
 		Interfaces     []Interface
 		Sysctls        []Sysctl
 		Mounts         []string
+		DNS            []string
+		DNSSearches    []string
 		HostNameIgnore bool
 		EntryPoint     string
 		ExtraArgs      string
@@ -624,6 +630,30 @@ func TestNode_CreateNode(t *testing.T) {
 			want: []string{"docker run -td --net none --name T1 --rm --privileged --hostname T1 -v /tmp/tinet:/tinet -v `pwd`:/mnt/test -v /usr/share/vim:/mnt/vim slankdev/frr"},
 		},
 		{
+			name: "create node with DNS",
+			fields: fields{
+				Name:  "R1",
+				Image: "slankdev/frr",
+				NetBase: "bridge",
+				Interfaces: []Interface{
+					Interface{
+						Name: "net0",
+						Type: "direct",
+						Args: "C1#net0",
+					},
+				},
+				DNS: []string{
+					"8.8.8.8",
+					"1.1.1.1",
+				},
+				DNSSearches: []string{
+					"local",
+					"corp",
+				},
+			},
+			want: []string{"docker run -td --net bridge --name R1 --rm --privileged --hostname R1 -v /tmp/tinet:/tinet --dns=8.8.8.8 --dns=1.1.1.1 --dns-search=local --dns-search=corp slankdev/frr"},
+		},
+		{
 			name: "create node with specify tinet volume",
 			fields: fields{
 				Name:       "T1",
@@ -701,6 +731,8 @@ func TestNode_CreateNode(t *testing.T) {
 				Interfaces:     tt.fields.Interfaces,
 				Sysctls:        tt.fields.Sysctls,
 				Mounts:         tt.fields.Mounts,
+				DNS:            tt.fields.DNS,
+				DNSSearches:    tt.fields.DNSSearches,
 				HostNameIgnore: tt.fields.HostNameIgnore,
 				EntryPoint:     tt.fields.EntryPoint,
 				ExtraArgs:      tt.fields.ExtraArgs,
@@ -1089,6 +1121,8 @@ func TestNode_DelNsCmd(t *testing.T) {
 		Interfaces     []Interface
 		Sysctls        []Sysctl
 		Mounts         []string
+		DNS            []string
+		DNSSearches    []string
 		HostNameIgnore bool
 		EntryPoint     string
 		ExtraArgs      string
@@ -1125,6 +1159,8 @@ func TestNode_DelNsCmd(t *testing.T) {
 				Interfaces:     tt.fields.Interfaces,
 				Sysctls:        tt.fields.Sysctls,
 				Mounts:         tt.fields.Mounts,
+				DNS:            tt.fields.DNS,
+				DNSSearches:    tt.fields.DNSSearches,
 				HostNameIgnore: tt.fields.HostNameIgnore,
 				EntryPoint:     tt.fields.EntryPoint,
 				ExtraArgs:      tt.fields.ExtraArgs,


### PR DESCRIPTION
This pull request adds `dns` and `dns_search` options.

Example,
```
nodes:
  - name: R1
    image: slankdev/frr
    interfaces:
      - { name: net0, type: direct, args: C1#net0 }
    net_base: bridge
    dns:
      - 8.8.8.8
      - 1.1.1.1
    dns_search:
      - local
      - corp
```
This spec is extract as follow:
```
docker run -td --net bridge --name R1 --rm --privileged --hostname R1 -v /tmp/tinet:/tinet --dns=8.8.8.8 --dns=1.1.1.1 --dns-search=local --dns-search=corp slankdev/frr
```
