### PR TITLE
Make `tinet build` (buildfile option) work

### DIFF
--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -56,6 +56,7 @@ type Node struct {
 	VolumeBase     string                 `yaml:"volume" mapstructure:"volume"`
 	Image          string                 `yaml:"image" mapstructure:"image"`
 	BuildFile      string                 `yaml:"buildfile" mapstructure:"buildfile"`
+	BuildContext   string                 `yaml:"buildcontext" mapstructure:"buildcontext"`
 	Interfaces     []Interface            `yaml:"interfaces" mapstructure:"interfaces"`
 	Sysctls        []Sysctl               `yaml:"sysctls" mapstructure:"sysctls"`
 	Mounts         []string               `yaml:"mounts,flow" mapstructure:"mounts,flow"`
@@ -113,8 +114,13 @@ type Test struct {
 // BuildCmd
 func (node *Node) BuildCmd() (buildCmd string) {
 
+	buildContext := "."
+	if node.BuildContext != "" {
+		buildContext = node.BuildContext
+	}
+
 	if node.BuildFile != "" {
-		buildCmd = fmt.Sprintf("docker build -t %s %s", node.Image, node.BuildFile)
+		buildCmd = fmt.Sprintf("docker build -t %s -f %s %s", node.Image, node.BuildFile, buildContext)
 	}
 
 	return buildCmd


### PR DESCRIPTION
Currently when we set "buildfile: Dockerfile" and "image: foo:latest"
node options, `tinet build` produces following command.

docker build -t foo:latest Dockerfile

There are several missing stuff in here. First it needs -f option to
specify Dockerfile path. And second, it doesn't have build context (e.g.
.). Overall, the correct command should look like this.

docker build -t foo:latest -f Dockerfile .

First issue can be solved by adding missing -f option. However, for the
second issue, we don't have any way to specify build context in current
manifest. Thus, this commit adds new node option "buildcontext" as well.

Signed-off-by: Yutaro Hayakawa <yhayakawa3720@gmail.com>