### PR TITLE
Fix macaddr bug

### DIFF
--- a/command_func.go
+++ b/command_func.go
@@ -185,6 +185,10 @@ func CmdUp(c *cli.Context) error {
 					n2nLinkCmds := inf.N2nLink(node.Name)
 					utils.PrintCmds(os.Stdout, n2nLinkCmds, verbose)
 				}
+				if len(inf.Addr) != 0 {
+					addrSetCmd := inf.AddrSet(node.Name)
+					utils.PrintCmd(os.Stdout, addrSetCmd, verbose)
+				}
 			} else if inf.Type == "bridge" {
 				s2nLinkCmds := inf.S2nLink(node.Name)
 				utils.PrintCmds(os.Stdout, s2nLinkCmds, verbose)

--- a/docs/specification_yml.md
+++ b/docs/specification_yml.md
@@ -31,7 +31,7 @@ nodes:
 	- direct: p2p connect to other container
 	- bridge: bridge connection
 	- phys  : host's network interface
-- mac: specify mac address
+- addr: specify mac address
 
 ```
 nodes:
@@ -41,7 +41,7 @@ nodes:
       - { name: net0, type: direct, args: R0#net1 }
       - { name: net0, type: bridge, args: B0 }
       - { name: eth0, type: phys }
-      - { name: net0, type: direct, args: R1#net1, mac: 11:11:11:11:11:11 }
+      - { name: net0, type: direct, args: R1#net1, addr: 11:11:11:11:11:11 }
 ```
 
 ### Bridge Definition

--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -510,6 +510,13 @@ func NetnsLinkUp(netnsName string, linkName string) (netnsLinkUpCmd string) {
 	return netnsLinkUpCmd
 }
 
+func (inf *Interface) AddrSet(nodeName string) (addrSetCmd string) {
+
+	addrSetCmd = fmt.Sprintf("ip netns exec %s ip link set %s address %s", nodeName, inf.Name, inf.Addr)
+
+	return addrSetCmd
+}
+
 // CreateSwitch Create bridge set in config
 func (bridge *Switch) CreateSwitch() (createSwitchCmds []string) {
 
@@ -533,11 +540,6 @@ func (inf *Interface) N2nLink(nodeName string) (n2nLinkCmds []string) {
 	n2nLinkCmds = append(n2nLinkCmds, n2nlinkCmd)
 	n2nLinkCmds = append(n2nLinkCmds, NetnsLinkUp(nodeName, nodeinf))
 	n2nLinkCmds = append(n2nLinkCmds, NetnsLinkUp(peerNode, peerinf))
-
-	if len(inf.Addr) != 0 {
-		addrSetCmd := fmt.Sprintf("ip netns exec %s ip link set %s address %s", nodeName, inf.Name, inf.Addr)
-		n2nLinkCmds = append(n2nLinkCmds, addrSetCmd)
-	}
 
 	return n2nLinkCmds
 }


### PR DESCRIPTION
このパッチは nodes > interface  > addr フィールドを利用してインターフェイスの MAC アドレスを指定する機能のバグの修正です．

このバグは，yaml ファイルで指定された MAC アドレスを割り振る処理を [N2nLink 関数](https://github.com/tinynetwork/tinet/blob/master/internal/pkg/shell/shell.go#L537) の中で行っていたために発生していました．

```spec.yaml
nodes:
- name: Router
  image: sabaniki/frr:latest
  interfaces:
  - { name: vm1, type: direct, args: VM1#rt, addr: 10:00:00:00:00:10 }
  - { name: vm2, type: direct, args: VM2#rt, addr: 20:00:00:00:00:20 }
  - { name: vm3, type: direct, args: VM3#rt, addr: 30:00:00:00:00:30 }

- name: VM1
  image: sabaniki/frr:latest
  interfaces:
  - { name: rt, type: direct, args: Router#vm1, addr: 10:10:10:10:10:10 }

- name: VM2
  image: sabaniki/frr:latest
  interfaces:
  - { name: rt, type: direct, args: Router#vm2, addr: 20:20:20:20:20:20 }

- name: VM3
  image: sabaniki/frr:latest
  interfaces:
  - { name: rt, type: direct, args: Router#vm3, addr: 30:30:30:30:30:30 }
```
上記の spec.yaml に対して `tinet up` を実行すると，出力は以下の通りとなり，VM 側のインターフェイスの MAC アドレスが指定されていません．
```
docker run -td --net none --name Router --rm --privileged --hostname Router -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect Router --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/Router > /dev/null
docker run -td --net none --name VM1 --rm --privileged --hostname VM1 -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect VM1 --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/VM1 > /dev/null
docker run -td --net none --name VM2 --rm --privileged --hostname VM2 -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect VM2 --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/VM2 > /dev/null
docker run -td --net none --name VM3 --rm --privileged --hostname VM3 -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect VM3 --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/VM3 > /dev/null
ip link add vm1 netns Router type veth peer name rt netns VM1 > /dev/null
ip netns exec Router ip link set vm1 up > /dev/null
ip netns exec VM1 ip link set rt up > /dev/null
ip netns exec Router ip link set vm1 address 10:00:00:00:00:10 > /dev/null
ip link add vm2 netns Router type veth peer name rt netns VM2 > /dev/null
ip netns exec Router ip link set vm2 up > /dev/null
ip netns exec VM2 ip link set rt up > /dev/null
ip netns exec Router ip link set vm2 address 20:00:00:00:00:20 > /dev/null
ip link add vm3 netns Router type veth peer name rt netns VM3 > /dev/null
ip netns exec Router ip link set vm3 up > /dev/null
ip netns exec VM3 ip link set rt up > /dev/null
ip netns exec Router ip link set vm3 address 30:00:00:00:00:30 > /dev/null
ip netns del Router > /dev/null
ip netns del VM1 > /dev/null
ip netns del VM2 > /dev/null
ip netns del VM3 > /dev/null
```

N2n関数は [CmdUp 関数](https://github.com/tinynetwork/tinet/blob/master/command_func.go#L185) の中でノードを接続するために実行されます．Router#vm1 と VM1#rt をつなげる際，Router#vm1 に対してのみ実行され，VM1#rt に対してはスキップされます．そのため，VM1#rt に対して MAC アドレスを指定する処理が行われません．

バグ修正後の実行結果は以下のとおりです．
```diff
docker run -td --net none --name Router --rm --privileged --hostname Router -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect Router --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/Router > /dev/null
docker run -td --net none --name VM1 --rm --privileged --hostname VM1 -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect VM1 --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/VM1 > /dev/null
docker run -td --net none --name VM2 --rm --privileged --hostname VM2 -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect VM2 --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/VM2 > /dev/null
docker run -td --net none --name VM3 --rm --privileged --hostname VM3 -v /tmp/tinet:/tinet sabaniki/frr:latest > /dev/null
mkdir -p /var/run/netns > /dev/null
PID=`docker inspect VM3 --format '{{.State.Pid}}'` > /dev/null
ln -s /proc/$PID/ns/net /var/run/netns/VM3 > /dev/null
ip link add vm1 netns Router type veth peer name rt netns VM1 > /dev/null
ip netns exec Router ip link set vm1 up > /dev/null
ip netns exec VM1 ip link set rt up > /dev/null
ip netns exec Router ip link set vm1 address 10:00:00:00:00:10 > /dev/null
ip link add vm2 netns Router type veth peer name rt netns VM2 > /dev/null
ip netns exec Router ip link set vm2 up > /dev/null
ip netns exec VM2 ip link set rt up > /dev/null
ip netns exec Router ip link set vm2 address 20:00:00:00:00:20 > /dev/null
ip link add vm3 netns Router type veth peer name rt netns VM3 > /dev/null
ip netns exec Router ip link set vm3 up > /dev/null
ip netns exec VM3 ip link set rt up > /dev/null
ip netns exec Router ip link set vm3 address 30:00:00:00:00:30 > /dev/null
+ ip netns exec VM1 ip link set rt address 10:10:10:10:10:10 > /dev/null
+ ip netns exec VM2 ip link set rt address 20:20:20:20:20:20 > /dev/null
+ ip netns exec VM3 ip link set rt address 30:30:30:30:30:30 > /dev/null
ip netns del Router > /dev/null
ip netns del VM1 > /dev/null
ip netns del VM2 > /dev/null
ip netns del VM3 > /dev/null
```

また，プログラム上は MAC アドレスの指定は`addr: XX:XX:XX:XX:XX:XX`で行われることを想定していますが，ドキュメント上は`mac: XX:XX:XX:XX:XX:XX`となっていたため，これについても修正しました．