### PR TITLE
feature: Add label for img output node links

### DIFF
--- a/command_func.go
+++ b/command_func.go
@@ -310,7 +310,7 @@ func CmdExec(c *cli.Context) error {
 }
 
 func CmdImg(c *cli.Context) error {
-
+	format := c.String("format")
 	tnconfig, _, err := LoadCfg(c)
 	if err != nil {
 		return err
@@ -332,9 +332,21 @@ func CmdImg(c *cli.Context) error {
 					newEdge := g.Edge(fromNode, toNode)
 					newEdge.Attr("arrowhead", "none")
 					newEdge.Attr("labelfloat", "true")
+					taillabel := ""
+					if ifaceInfo.Label != "" {
+						taillabel = fmt.Sprintf("%s(%s)", ifaceInfo.Name, ifaceInfo.Label)
+					} else {
+						taillabel = ifaceInfo.Name
+					}
 					newEdge.Attr("headlabel", strings.Split(ifaceInfo.Args, "#")[1])
-					newEdge.Attr("taillabel", ifaceInfo.Name)
+					newEdge.Attr("taillabel", taillabel)
 					newEdge.Attr("fontsize", "8")
+				} else {
+					edge := findEdges[0]
+					if ifaceInfo.Label != "" {
+						headlabel := fmt.Sprintf("%s(%s)", edge.GetAttr("headlabel"), ifaceInfo.Label)
+						edge.Attr("headlabel", headlabel)
+					}
 				}
 			} else if ifaceInfo.Type == "bridge" {
 				argsName = ifaceInfo.Args
@@ -345,14 +357,30 @@ func CmdImg(c *cli.Context) error {
 					newEdge.Attr("arrowhead", "none")
 					newEdge.Attr("labelfloat", "true")
 					newEdge.Attr("headlabel", argsName)
-					newEdge.Attr("taillabel", ifaceInfo.Name)
+					taillabel := ""
+					if ifaceInfo.Label != "" {
+						taillabel = fmt.Sprintf("%s(%s)", ifaceInfo.Name, ifaceInfo.Label)
+					} else {
+						taillabel = ifaceInfo.Name
+					}
+					newEdge.Attr("taillabel", taillabel)
 					newEdge.Attr("fontsize", "8")
+				} else {
+					edge := findEdges[0]
+					if ifaceInfo.Label != "" {
+						headlabel := fmt.Sprintf("%s(%s)", edge.GetAttr("headlabel"), ifaceInfo.Label)
+						edge.Attr("headlabel", headlabel)
+					}
 				}
 			}
 		}
 	}
 
-	fmt.Fprintln(os.Stdout, g.String())
+	if format == "mermaid" {
+		fmt.Println(dot.MermaidGraph(g, dot.MermaidTopToBottom))
+	} else {
+		fmt.Fprintln(os.Stdout, g.String())
+	}
 
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -139,6 +139,12 @@ var commandImg = &cli.Command{
 			Usage:   "Specify the Config file.",
 			Value:   "spec.yaml",
 		},
+		&cli.StringFlag{
+			Name:    "format",
+			Aliases: []string{"f"},
+			Usage:   "Image output format",
+			Value:   "graphviz",
+		},
 	},
 }
 

--- a/configs/spec_template.yaml
+++ b/configs/spec_template.yaml
@@ -20,6 +20,7 @@ nodes:
     type: ""
     args: ""
     addr: ""
+    label: ""
   sysctls: []
 switches:
 - name: ""

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tinynetwork/tinet
 go 1.13
 
 require (
-	github.com/emicklei/dot v0.10.2
+	github.com/emicklei/dot v1.6.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.6.2
 	github.com/urfave/cli/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/emicklei/dot v0.10.2 h1:vDUudhCSkKr1G3kieHqm3CiP7AsvaM25qk+46kb1i5Q=
 github.com/emicklei/dot v0.10.2/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
+github.com/emicklei/dot v1.6.0 h1:vUzuoVE8ipzS7QkES4UfxdpCwdU2U97m2Pb2tQCoYRY=
+github.com/emicklei/dot v1.6.0/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -71,10 +71,11 @@ type Node struct {
 
 // Interface
 type Interface struct {
-	Name string `yaml:"name"`
-	Type string `yaml:"type"`
-	Args string `yaml:"args"`
-	Addr string `yaml:"addr"`
+	Name  string `yaml:"name"`
+	Type  string `yaml:"type"`
+	Args  string `yaml:"args"`
+	Addr  string `yaml:"addr"`
+	Label string `yaml:"label"`
 }
 
 // Sysctl

--- a/internal/pkg/shell/shell_test.go
+++ b/internal/pkg/shell/shell_test.go
@@ -799,19 +799,6 @@ func TestInterface_N2nLink(t *testing.T) {
 			},
 			want: []string{"ip link add net0 netns R1 type veth peer name net0 netns R2", "ip netns exec R1 ip link set net0 up", "ip netns exec R2 ip link set net0 up"},
 		},
-		{
-			name: "peer between containers and set macaddress",
-			fields: fields{
-				Name: "net0",
-				Type: "direct",
-				Args: "R2#net0",
-				Addr: "52:54:00:11:11:11",
-			},
-			args: args{
-				nodeName: "R1",
-			},
-			want: []string{"ip link add net0 netns R1 type veth peer name net0 netns R2", "ip netns exec R1 ip link set net0 up", "ip netns exec R2 ip link set net0 up", "ip netns exec R1 ip link set net0 address 52:54:00:11:11:11"},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I want to add information such as IP address to the output of graphviz.
And, just add `mermaid` output format that only graph connection.

Example:
```
nodes:
- name: client
  image: nicolaka/netshoot
  interfaces:
  - { name: net0, type: direct, args: R1#net0, label: "10.0.0.2/24"}
- name: R1
  image: nicolaka/netshoot
  interfaces:
  - { name: net0, type: direct, args: client#net0, label: "10.0.0.1/24"}
  - { name: net1, type: direct, args: root#net0 , label: "10.0.1.1/24"}
  - { name: net2, type: direct, args: resolver#net0 , label: "10.0.2.1/24"}
  - { name: net3, type: direct, args: nomns#net0, label: "10.0.3.1/24"}
- name: root
  image: nicolaka/netshoot
  interfaces:
  - { name: net0, type: direct, args: R1#net1, label: "10.0.1.2/24"}
- name: resolver
  image: nicolaka/netshoot
  interfaces:
  - { name: net0, type: direct, args: R1#net2, label: "10.0.2.2/24"}
- name: nomns
  image: nicolaka/netshoot
  interfaces:
    - { name: net0, type: direct, args: R1#net3, label: "10.0.3.2/24"}
```
```
digraph  {

	n2[label="R1"];
	n1[label="client"];
	n5[label="nomns"];
	n4[label="resolver"];
	n3[label="root"];
	n2->n3[arrowhead="none",fontsize="8",headlabel="net0(10.0.1.2/24)",labelfloat="true",taillabel="net1(10.0.1.1/24)"];
	n2->n4[arrowhead="none",fontsize="8",headlabel="net0(10.0.2.2/24)",labelfloat="true",taillabel="net2(10.0.2.1/24)"];
	n2->n5[arrowhead="none",fontsize="8",headlabel="net0(10.0.3.2/24)",labelfloat="true",taillabel="net3(10.0.3.1/24)"];
	n1->n2[arrowhead="none",fontsize="8",headlabel="net0(10.0.0.1/24)",labelfloat="true",taillabel="net0(10.0.0.2/24)"];

}
```

```
$ ./tinet img -c example.yaml  -f mermaid
graph TD;
	n2("R1");
	n1("client");
	n5("nomns");
	n4("resolver");
	n3("root");
	n2-->n3;
	n2-->n4;
	n2-->n5;
	n1-->n2;
```