### PR TITLE
Add auto generate release note config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - feature
+    - title: Fixes
+      labels:
+        - fix
+    - title: Examples
+      labels:
+        - examples
+    - title: GitHub Actions
+      labels:
+        - github_actions
+    - title: Dockerfile
+      labels:
+        - dockerfiles
+    - title: Docs
+      labels:
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Use this function to generate release notes.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

Working with #121 .