### PR TITLE
feature: preconf

### DIFF
--- a/command_func.go
+++ b/command_func.go
@@ -244,6 +244,13 @@ func CmdConf(c *cli.Context) error {
 		nodeinfo[node.Name] = node.Type
 	}
 
+	if len(tnconfig.PreConf) != 0 {
+		for _, preConf := range tnconfig.PreConf {
+			preConfCmds := shell.ExecCmd(preConf.Cmds)
+			utils.PrintCmds(os.Stdout, preConfCmds, verbose)
+		}
+	}
+
 	for _, nodeConfig := range tnconfig.NodeConfigs {
 		execConfCmds := nodeConfig.ExecConf(nodeinfo[nodeConfig.Name])
 		for _, execConfCmd := range execConfCmds {

--- a/configs/spec_template.yaml
+++ b/configs/spec_template.yaml
@@ -4,6 +4,9 @@ precmd:
 preinit:
 - cmds:
   - cmd: ""
+preconf:
+- cmds:
+  - cmd: ""
 postinit:
 - cmds:
   - cmd: ""

--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -19,6 +19,7 @@ var log = l.New()
 type Tn struct {
 	PreCmd      []PreCmd     `yaml:"precmd"`
 	PreInit     []PreInit    `yaml:"preinit"`
+	PreConf     []PreConf    `yaml:"preconf"`
 	PostInit    []PostInit   `yaml:"postinit"`
 	PostFini    []PostFini   `yaml:"postfini"`
 	Nodes       []Node       `yaml:"nodes" mapstructure:"nodes"`
@@ -35,6 +36,11 @@ type PreCmd struct {
 
 // PreInit
 type PreInit struct {
+	Cmds []Cmd `yaml:"cmds" mapstructure:"cmds"`
+}
+
+// PreConf
+type PreConf struct {
 	Cmds []Cmd `yaml:"cmds" mapstructure:"cmds"`
 }
 
@@ -232,6 +238,13 @@ func GenerateFile() (genContent string, err error) {
 			},
 		},
 	}
+	preconf := PreConf{
+		Cmds: []Cmd{
+			Cmd{
+				Cmd: "",
+			},
+		},
+	}
 	postinit := PostInit{
 		Cmds: []Cmd{
 			Cmd{
@@ -341,6 +354,7 @@ func GenerateFile() (genContent string, err error) {
 	tnconfig := &Tn{
 		PreCmd:      []PreCmd{precmd},
 		PreInit:     []PreInit{preinit},
+		PreConf:     []PreConf{preconf},
 		PostInit:    []PostInit{postinit},
 		PostFini:    []PostFini{postfini},
 		Nodes:       []Node{nodes},

--- a/internal/pkg/shell/shell_test.go
+++ b/internal/pkg/shell/shell_test.go
@@ -229,6 +229,7 @@ func TestTn_Exec(t *testing.T) {
 	type fields struct {
 		PreCmd      []PreCmd
 		PreInit     []PreInit
+		PreConf     []PreConf
 		PostInit    []PostInit
 		PostFini    []PostFini
 		Nodes       []Node
@@ -253,6 +254,7 @@ func TestTn_Exec(t *testing.T) {
 			tnconfig := &Tn{
 				PreCmd:      tt.fields.PreCmd,
 				PreInit:     tt.fields.PreInit,
+				PreConf:     tt.fields.PreConf,
 				PostInit:    tt.fields.PostInit,
 				PostFini:    tt.fields.PostFini,
 				Nodes:       tt.fields.Nodes,


### PR DESCRIPTION
I would like to add preconf configuration that is originally implemented on slankdev/tinet. I am heavily using it for define global variables used in every node configurations like as below:
```
preconf:
  - cmds:
      - cmd: ROUTER_ID_PREFIX='10.255.0'

node_configs:
  - name: R1
    cmds:
      - cmd: /usr/lib/frr/frr start
      - cmd: >-
          vtysh -c "conf t"
          -c "bgp router-id $ROUTER_ID_PREFIX.1"
  - name: R2
    cmds:
      - cmd: /usr/lib/frr/frr start
      - cmd: >-
          vtysh -c "conf t"
          -c "bgp router-id $ROUTER_ID_PREFIX.2"
```

```sh
$ tinet conf -c spec.yaml
ROUTER_ID_PREFIX='10.255.0' > /dev/null
docker exec R1 /usr/lib/frr/frr start > /dev/null
docker exec R1 vtysh -c "conf t" -c "bgp router-id $ROUTER_ID_PREFIX.1" > /dev/null
docker exec R2 /usr/lib/frr/frr start > /dev/null
docker exec R2 vtysh -c "conf t" -c "bgp router-id $ROUTER_ID_PREFIX.2" > /dev/null
```