### PR TITLE
fix: "tinet exec" generates invalid commands

### DIFF
--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -213,8 +213,8 @@ func (tnconfig *Tn) Exec(nodeName string, Cmds []string) (execCommand string) {
 		var cmdStr string
 		for _, cmd := range Cmds {
 			cmdStr += fmt.Sprintf(" %s", cmd)
-			execCommand += cmdStr
 		}
+		execCommand += cmdStr
 	}
 
 	return execCommand


### PR DESCRIPTION
Before:
```sh
$ tinet exec R1 a b c d e
docker exec R1 a a b a b c a b c d a b c d e > /dev/null
```

After:
```sh
$ tinet exec R1 a b c d e
docker exec R1 a b c d e > /dev/null
```