### PR TITLE
added verbose option in tinet exec

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -125,6 +125,11 @@ var commandExec = &cli.Command{
 			Usage:   "Specify the Config file.",
 			Value:   "spec.yaml",
 		},
+		&cli.BoolFlag{
+			Name:    "verbose",
+			Aliases: []string{"v"},
+			Usage:   "Verbose",
+		},
 	},
 }
 


### PR DESCRIPTION
I would like to add verbose option in "tinet exec" to execute show commands.